### PR TITLE
Add support link to email template

### DIFF
--- a/inc/mail/order_template.php
+++ b/inc/mail/order_template.php
@@ -47,7 +47,9 @@ $mail_message = <<<EOD
             Please make a total payment fee of
             <b>Ð $amount</b> to the Dogecoin address <b>$paytoDogeAddress</b>
             <br><br>
-            After payment you should receive a confirmation email.
+            After payment you will receive a confirmation email.
+            <br><br>
+            Need help? Contact us at <a href="mailto:hackathon@dogecoin.org">hackathon@dogecoin.org</a>
             <br><br>
             Much Thanks!
         </div>

--- a/inc/mail/payment_template.php
+++ b/inc/mail/payment_template.php
@@ -42,9 +42,11 @@ $mail_message = <<<EOD
         <!-- Email body with white text -->
         <div class="email-body">
             <h2>Hello $name</h2>
-            Your payment fee for the Dogeathon Portugal is confirmed.
+            Your payment for Dogeathon Portugal has been received.
             <br><br>
             Dont forget to visit <a href="https://dogecoin.com/dogeathon" target="_blank">https://dogecoin.com/dogeathon</a> for all details.
+            <br><br>
+            Need help? Contact us at <a href="mailto:hackathon@dogecoin.org">hackathon@dogecoin.org</a>
             <br><br>
             Much Thanks!
         </div>


### PR DESCRIPTION
This PR
- Adds support email to outgoing email templates

Tweaks some language:
-  "you should receive an email" to "you will"
- payment has been received.